### PR TITLE
fix: spelling in the description of Stable Diffusion Prompts Crafter

### DIFF
--- a/src/stable-diffusion.json
+++ b/src/stable-diffusion.json
@@ -8,7 +8,7 @@
   "identifier": "stable-diffusion",
   "meta": {
     "avatar": "🦄",
-    "description": "This GPT helps create precise prompts for Stable Diffusion. You will get descriptions, prompts, and negative prompts. prompts and negative promps are in plain text code blocks for easy copy.",
+    "description": "This GPT helps create precise prompts for Stable Diffusion. You will get descriptions, prompts, and negative prompts. prompts and negative prompts are in plain text code blocks for easy copy.",
     "tags": ["stable-diffusion"],
     "title": "Stable Diffusion Prompts Crafter"
   },


### PR DESCRIPTION
#### 📝 信息 | Information

Fixed a spelling error in the description of Stable Diffusion Prompts Crafter.

#### ✅ 检查列表 | Checklist:

<!--- Checkboxes will become clickable after submit, no need to fill them now --->

- [x] 我已阅读了 [`Readme.md`](https://github.com/lobehub/lobe-chat-agents/)
- [x] 描述是用英文编写的。
- [x] `meta.json` 和 `agent_template.json` 没有被修改过。
- [x] `entry` 放置在 `agents` 目录中，并且使用 `.json` 文件扩展名。

---

- [x] I have read the [`Readme.md`](https://github.com/lobehub/lobe-chat-agents/)
- [x] The description is written in English.
- [x] The `meta.json` and `agent_template.json` have not been modified.
- [x] The `entry` is placed in the `agents` directory with the `.json` file extension.
