### PR TITLE
Using ELD version 2, with static import, instead of fork with await.

### DIFF
--- a/.cursor/rules/i18n-translation-system.mdc
+++ b/.cursor/rules/i18n-translation-system.mdc
@@ -55,7 +55,7 @@ private getIncrementalData = (sourceData: any, existingData: any) => {
 ## 🛡️ Language Validation
 
 ### Validation Process
-Uses `@yutengjing/eld` library for language detection:
+Uses `eld` library for language detection:
 
 ```typescript
 import { validateTranslationLanguage } from '../validators/language-validator';

--- a/.cursor/rules/scripts-architecture.mdc
+++ b/.cursor/rules/scripts-architecture.mdc
@@ -25,7 +25,7 @@ This project uses a modular scripts directory structure for maintainability and 
 
 ### Validation Modules
 - **[scripts/validators/agent-validator.ts](mdc:scripts/validators/agent-validator.ts)** - Schema validation and formatting
-- **[scripts/validators/language-validator.ts](mdc:scripts/validators/language-validator.ts)** - Language detection and validation using @yutengjing/eld
+- **[scripts/validators/language-validator.ts](mdc:scripts/validators/language-validator.ts)** - Language detection and validation using eld
 
 ### Build System
 - **[scripts/builders/agent-builder.ts](mdc:scripts/builders/agent-builder.ts)** - Build all language versions of Agent files

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.17.16",
-    "@yutengjing/eld": "^0.0.2",
+    "eld": "^2.0.3",
     "consola": "^3.4.0",
     "dayjs": "^1.11.13",
     "dirty-json": "^0.9.2",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -64,7 +64,7 @@ scripts/
 ### 验证器模块 (validators/)
 
 - **agent-validator.ts**: 验证 Agent 配置格式和数据完整性
-- **language-validator.ts**: 使用 @yutengjing/eld 库验证翻译文件的语言准确性
+- **language-validator.ts**: 使用 eld 库验证翻译文件的语言准确性
 
 ### 构建器模块 (builders/)
 
@@ -131,7 +131,7 @@ pnpm run update:awesome
 
 ### 🛡️ 语言验证系统
 
-- **自动检测**: 使用 @yutengjing/eld 库检测翻译文件的实际语言
+- **自动检测**: 使用 eld 库检测翻译文件的实际语言
 - **准确性验证**: 确保翻译结果与预期语言代码匹配
 - **批量处理**: 支持批量验证和自动清理无效文件
 - **详细报告**: 提供置信度、问题详情等详细信息

--- a/scripts/commands/validate-language.ts
+++ b/scripts/commands/validate-language.ts
@@ -11,7 +11,6 @@ import { Logger } from '../utils/logger';
 import {
   LanguageValidationResult,
   ValidationStats,
-  ensureELDInitialized,
   fixLanguageIssues,
   fixLanguageWithFallback,
   validateTranslationLanguage,
@@ -83,9 +82,6 @@ async function validateAllLanguages(
     Logger.warn('没有找到翻译文件');
     return;
   }
-
-  // 预先初始化 ELD 语言检测器，避免并发初始化问题
-  await ensureELDInitialized();
 
   const stats: ValidationStats = {
     total: files.length,

--- a/scripts/validators/language-validator.ts
+++ b/scripts/validators/language-validator.ts
@@ -1,26 +1,8 @@
-import { eld } from '@yutengjing/eld';
+import { eld } from 'eld/large';
 import { existsSync } from 'node:fs';
 
 import { readJSONSync, writeJSON } from '../utils/file';
 import { Logger } from '../utils/logger';
-
-// 语言检测器初始化Promise，确保只初始化一次
-let initPromise: Promise<void> | null = null;
-
-/**
- * 初始化 ELD 语言检测器
- * 使用中等规模的 ngram 数据集
- */
-async function initializeELD(): Promise<void> {
-  if (!initPromise) {
-    initPromise = (async () => {
-      Logger.info('🔧 初始化 ELD 语言检测器...');
-      await eld.init('M'); // 使用中等规模的数据集
-      Logger.success('✅ ELD 语言检测器初始化完成');
-    })();
-  }
-  return initPromise;
-}
 
 // ISO 639-1 to project locale code mapping
 const languageMap: { [key: string]: string } = {
@@ -206,13 +188,6 @@ function isIgnored(filePath: string): boolean {
 }
 
 /**
- * 确保 ELD 已初始化（公开函数，供外部调用）
- */
-export async function ensureELDInitialized(): Promise<void> {
-  await initializeELD();
-}
-
-/**
  * 检测文本的语言
  * @param text - 待检测的文本
  * @returns 语言检测结果对象
@@ -231,9 +206,6 @@ async function detectLanguage(text: string): Promise<{
       scores: {},
     };
   }
-
-  // 确保 ELD 已初始化（这里不会重复初始化）
-  await initializeELD();
 
   const result = eld.detect(text);
   const scores = result.getScores();


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat

#### 🔀 变更说明 | Description of Change

The same upgrade was also merged at @lobehub/lobe-cli-toolbox

From:
```js
import { eld } from '@yutengjing/eld';
//...
let initPromise: Promise<void> | null = null;

export async function initializeELD(): Promise<void> {
  if (!initPromise) {
    initPromise = (async () => {
      console.log('🔧 Initializing ELD language detector...');
      await eld.init('L'); // 使用中等规模的数据集
      console.log('✅ ELD language detector initialized');
    })();
  }
  return initPromise;
}
//...
 await initializeELD();
```
To:
```js
import { eld } from 'eld/large';
```

#### 📝 补充信息 | Additional Information


> **Changes from ELD v1 to v2**  
> 
> You can now import static eld with a specific database size:  
> `import { eld } from 'eld/large';`  
> 
> - ELD is now 1.5x faster, and more accurate.
> - TypeScript type definitions exported.
> - **npm** install size reduced by a 70%.


#### 📝 信息 | Information

<!--- Repo url or any other thing you like to say --->

#### ✅ 检查列表 | Checklist:

<!--- Checkboxes will become clickable after submit, no need to fill them now --->

- \[x] I have read the [`Readme.md`](https://github.com/lobehub/lobe-chat-agents/)
- \[x] The description is written in English.
- \[x] The `meta.json` and `agent_template.json` have not been modified.
- \[ ] The `entry` is placed in the `agents` directory with the `.json` file extension.
